### PR TITLE
Fix typo in cmsCloseProfile definition

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -10,7 +10,7 @@ Module.cmsOpenProfileFromMem = cwrap("cmsOpenProfileFromMem", "number", [
   "number",
 ]);
 
-Module.cmsCloseProfile = cwrap("cmsCreate_sRGBProfile", undefined, ["number"]);
+Module.cmsCloseProfile = cwrap("cmsCloseProfile", undefined, ["number"]);
 
 Module.cmsCreate_sRGBProfile = cwrap("cmsCreate_sRGBProfile", "number", []);
 


### PR DESCRIPTION
cmsCloseProfile has a typo - it's hooked up to the wrong function. 

Resolves https://github.com/mattdesl/lcms-wasm/issues/2