### PR TITLE
Add 'malloc' to exported symbols

### DIFF
--- a/lib/export.txt
+++ b/lib/export.txt
@@ -14,3 +14,4 @@ cmsGetTransformInputFormat
 cmsGetTransformOutputFormat
 cmsReadTag
 cmsXYZ2xyY
+malloc


### PR DESCRIPTION
When I tried running the demos from the readme, I get the following error:
```
RuntimeError: Aborted(malloc() called but not included in the build - add `_malloc` to EXPORTED_FUNCTIONS)
```
So I did what it said (add `_malloc` to export.txt) and it fixed it.  🤷 Maybe my version of emscripten is different? 