### PR TITLE
Bump TOTAL_STACK to 15MB

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ emcc \
   -s ALLOW_MEMORY_GROWTH=1\
   -s EXPORTED_RUNTIME_METHODS=["cwrap","ccall"]\
   -s EXPORTED_FUNCTIONS=$exported_opt\
-  -s TOTAL_STACK=5MB\
+  -s TOTAL_STACK=15MB\
   --post-js lib/api.js\
   --extern-post-js lib/post.js\
   --extern-pre-js lib/constants.js\


### PR DESCRIPTION
We are loading some rather large ICC profiles that are 13 MB and they were failing with `RangeError: offset is out of bounds` errors.  I follow the same pattern as before (https://github.com/mattdesl/lcms-wasm/issues/1) and bumped up the TOTAL_STACK to 15MB, which fixed it.