### PR TITLE
Account for extra bytes (like alpha) when allocating output array

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -198,8 +198,8 @@ function cmsDoTransform(transform, inputArr, size) {
   var outputFormat = cmsGetTransformOutputFormat(transform);
   var inputIsFloat = T_FLOAT(inputFormat); // Float64 or Uint16
   var outputIsFloat = T_FLOAT(outputFormat);
-  var inputChannels = T_CHANNELS(inputFormat); // 3(RGB) or 4(CMYK)
-  var outputChannels = T_CHANNELS(outputFormat);
+  var inputChannels = T_CHANNELS(inputFormat)+ T_EXTRA(inputFormat); // 3(RGB) or 4(CMYK)
+  var outputChannels = T_CHANNELS(outputFormat) + T_EXTRA(inputFormat);
   var inputBytes = T_BYTES(inputFormat); // Bytews per sample
   var outputBytes = T_BYTES(outputFormat);
   inputBytes = inputBytes < 1 ? 4 : inputBytes;


### PR DESCRIPTION
The `cmyk.js` demo program creates a 1024x1024 pixel array of 4 bytes per pixel, then passes those 4194304 bytes (1024*1024*4) into `cmsDoTransform`.  But the array we get back out is only 3145728 bytes (1024 * 1024 *3), and the resulting image is cut off.  

I'm not positive on the math here, but adding in the T_EXTRA(inputFormat) to both the inputChannels and outputChannels fixed it up so the bytes coming out of `cmsDoTransform` match the input length, at least for my RGBA files.