### PR TITLE
Adding cmsFLAGS_COPY_ALPHA to constants

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -511,3 +511,4 @@ export const cmsFLAGS_BLACKPOINTCOMPENSATION = 0x2000;
 export const cmsFLAGS_NOWHITEONWHITEFIXUP = 0x0004; // Don't fix scum dot
 export const cmsFLAGS_HIGHRESPRECALC = 0x0400; // Use more memory to give better accurancy
 export const cmsFLAGS_LOWRESPRECALC = 0x0800; // Use less memory to minimize resources
+export const cmsFLAGS_COPY_ALPHA = 0x04000000;


### PR DESCRIPTION
I found I need to pass the `cmsFLAGS_COPY_ALPHA` flag for RGBA images, otherwise the image comes out all garbled.  