### PR TITLE
More efficient buffer copies

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -204,14 +204,17 @@ function cmsDoTransform(transform, inputArr, size) {
   var outputBytes = T_BYTES(outputFormat);
   inputBytes = inputBytes < 1 ? 4 : inputBytes;
   outputBytes = outputBytes < 1 ? 4 : outputBytes;
-  var inputType = typeListByBytes(inputBytes, inputIsFloat);
-  var outputType = typeListByBytes(outputBytes, outputIsFloat);
   //
-  var inputBuffer = _malloc(inputChannels * inputBytes * size);
-  var outputBuffer = _malloc(outputChannels * outputBytes * size);
-  for (var i = 0; i < inputChannels * size; i++) {
-    setValue(inputBuffer + inputBytes * i, inputArr[i], inputType);
+  var inputBufferSize = inputChannels * inputBytes * size;
+  var inputBuffer = _malloc(inputBufferSize);
+  if (inputIsFloat) {
+    var dataOnHeap = new Float32Array(Module.HEAPU8.buffer, inputBuffer, inputBufferSize);
+  } else {
+    var dataOnHeap = new Uint8Array(Module.HEAPU8.buffer, inputBuffer, inputBufferSize);
   }
+  dataOnHeap.set(inputArr);
+  var outputBufferSize = outputChannels * outputBytes * size;
+  var outputBuffer = _malloc(outputBufferSize);
   ccall(
     "cmsDoTransform",
     undefined,
@@ -220,12 +223,9 @@ function cmsDoTransform(transform, inputArr, size) {
   );
 
   if (outputIsFloat) {
-    var outputArr = new Float32Array(outputChannels * size);
+    var outputArr = new Float32Array(Module.HEAPU8.buffer, outputBuffer, outputBufferSize);
   } else {
-    var outputArr = new Uint8Array(outputChannels * size);
-  }
-  for (var i = 0; i < outputChannels * size; i++) {
-    outputArr[i] = getValue(outputBuffer + outputBytes * i, outputType);
+    var outputArr = new Uint8Array(Module.HEAPU8.buffer, outputBuffer, outputBufferSize);
   }
   _free(inputBuffer);
   _free(outputBuffer);


### PR DESCRIPTION
When I was profiling the code I found that the buffer copies where taking a long time.  I was able to cut down the time by doing a single `set` call instead of looping over all the elements of the array.  